### PR TITLE
Template Debug output 

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,70 @@
+name: CI
+
+on:
+  push:
+    branches: [ main, master ]
+  pull_request:
+    branches: [ main, master ]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
+        django-version: ["4.2", "5.1", "5.2"]
+        exclude:
+          # Django 5.1+ requires Python 3.10+
+          - python-version: "3.8"
+            django-version: "5.1"
+          - python-version: "3.9"
+            django-version: "5.1"
+          - python-version: "3.8"
+            django-version: "5.2"
+          - python-version: "3.9"
+            django-version: "5.2"
+
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v4
+      with:
+        python-version: ${{ matrix.python-version }}
+
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install tox tox-gh-actions
+
+    - name: Run tests with tox
+      run: |
+        PYTHON_VERSION=${{ matrix.python-version }}
+        DJANGO_VERSION=${{ matrix.django-version }}
+        # Remove dots from Python version (3.10 -> 310)
+        PYTHON_VERSION=${PYTHON_VERSION//./}
+        # Convert Django version format (4.2 -> 4_2, 5.1 -> 5_1)
+        DJANGO_VERSION=${DJANGO_VERSION//./_}
+        echo "Running tox environment: py${PYTHON_VERSION}-django${DJANGO_VERSION}"
+        tox -e py${PYTHON_VERSION}-django${DJANGO_VERSION}
+
+  lint:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Set up Python
+      uses: actions/setup-python@v4
+      with:
+        python-version: "3.11"
+
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install -r dev-requirements.txt
+
+    - name: Run flake8
+      run: flake8 django_assert_queries

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -2,3 +2,8 @@
 pytest~=8.3.3
 pytest-django~=4.8.0
 pytest-env~=1.1.3
+kgb~=7.2
+typing_extensions~=4.4
+# Linting tools
+flake8~=7.0
+mypy~=1.0

--- a/django_assert_queries/query_catcher.py
+++ b/django_assert_queries/query_catcher.py
@@ -244,13 +244,15 @@ def catch_queries(
     def _query_add_q(
         _self: SQLQuery,
         q_object: Q,
+        *args,
+        **kwargs
     ) -> Any:
         try:
             queries_to_qs[_self] &= q_object
         except KeyError:
             queries_to_qs[_self] = q_object
 
-        return SQLQuery.add_q.call_original(_self, q_object)
+        return SQLQuery.add_q.call_original(_self, q_object, *args, **kwargs)
 
     # Copy Q() objects any time a Query is cloned.
     @spy_agency.spy_for(SQLQuery.clone, owner=SQLQuery)

--- a/django_assert_queries/query_catcher.py
+++ b/django_assert_queries/query_catcher.py
@@ -6,11 +6,15 @@ Version Added:
 
 from __future__ import annotations
 
+import inspect
+import os
 import traceback
 from contextlib import contextmanager
 from dataclasses import dataclass
 from enum import Enum
-from typing import Any, Dict, Iterator, List, Mapping, Sequence, Type, Union
+from typing import (
+    Any, Dict, Iterator, List, Mapping, Optional, Sequence, Type, Union
+)
 
 import kgb
 from django.core.exceptions import EmptyResultSet
@@ -25,7 +29,31 @@ from django.db.models.sql.compiler import (SQLCompiler,
 from django.db.models.sql.query import Query as SQLQuery
 from django.db.models.sql.subqueries import AggregateQuery
 from django.utils.tree import Node
-from typing_extensions import Literal, TypedDict
+from typing_extensions import Literal, NotRequired, TypedDict
+
+
+# Template debugging now uses Django's own infrastructure via stack inspection
+# No global state needed - we inspect the call stack during query execution
+
+
+class TemplateInfo(TypedDict):
+    """Information about the template where a query was executed.
+
+    Version Added:
+        2.1
+    """
+
+    #: The name of the template file.
+    name: str
+
+    #: The origin/path of the template.
+    origin: str
+
+    #: The line number in the template (if available).
+    line_number: NotRequired[int]
+
+    #: The line content where the query occurred (if available).
+    line_content: NotRequired[str]
 
 
 class ExecutedQueryType(str, Enum):
@@ -76,6 +104,9 @@ class ExecutedQueryInfo(TypedDict):
 
     #: The lines of traceback showing where the query was executed.
     traceback: List[str]
+
+    #: Information about the template where the query was executed (if any).
+    template_info: NotRequired[TemplateInfo]
 
     #: The type of executed query.
     type: ExecutedQueryType
@@ -139,6 +170,66 @@ class CatchQueriesContext:
     queries_to_qs: Dict[SQLQuery, Q]
 
 
+def _get_template_info_manual_fallback(template, node) -> TemplateInfo:
+    """Manual fallback when Django's get_exception_info can't work."""
+    template_info = {
+        'name': template.name or 'unknown',
+        'origin': template.origin.name if template.origin else 'unknown'
+    }
+
+    # Try to find line number by parsing template source manually
+    if (hasattr(template, 'source') and hasattr(node.token, 'contents') and
+            template.source and node.token.contents):
+        token_content = node.token.contents.strip()
+        for i, line in enumerate(template.source.split('\n'), 1):
+            if token_content in line:
+                template_info.update({
+                    'line_number': i,
+                    'line_content': line.strip()
+                })
+                break
+
+    return template_info
+
+
+def _get_line_info_from_node_origin(node) -> dict:
+    """Extract line information from the node's origin template."""
+    if not (hasattr(node, 'origin') and node.origin and
+            hasattr(node.token, 'position') and node.token.position):
+        return {}
+
+    origin_path = (node.origin.name if hasattr(node.origin, 'name')
+                   else str(node.origin))
+    if not os.path.isfile(origin_path):
+        return {}
+
+    with open(origin_path, 'r', encoding='utf-8') as f:
+        source_lines = f.readlines()
+
+    # Extract line number from token position
+    line_number = (node.token.position[0]
+                   if isinstance(node.token.position, tuple)
+                   else int(node.token.position))
+
+    if 1 <= line_number <= len(source_lines):
+        return {
+            'line_number': line_number,
+            'line_content': source_lines[line_number - 1].strip()
+        }
+
+    # Fallback: search for token content in source
+    if hasattr(node.token, 'contents') and node.token.contents:
+        token_content = node.token.contents.strip()
+        for i, line in enumerate(source_lines, 1):
+            if token_content in line:
+                return {
+                    'line_number': i,
+                    'line_content': line.strip()
+                }
+
+    return {}
+
+
 @contextmanager
 def catch_queries(
     *,
@@ -178,6 +269,110 @@ def catch_queries(
     executed_queries: List[ExecutedQueryInfo] = []
     queries_to_qs: Dict[SQLQuery, Q] = {}
 
+    def _get_template_info_for_query(_self) -> Optional[List[TemplateInfo]]:
+        """Extract template debugging info showing the entire inheritance
+        chain."""
+        template_chain = []
+        seen_templates = set()
+
+        for frame_info in inspect.stack():
+            frame = frame_info.frame
+
+            # Quick validation of frame locals
+            if not all(key in frame.f_locals
+                       for key in ('context', 'self')):
+                continue
+
+            context = frame.f_locals['context']
+            node = frame.f_locals['self']
+
+            # Validate template context
+            if not (hasattr(context, 'render_context') and
+                    hasattr(node, 'token') and hasattr(node, 'render') and
+                    node.token is not None):
+                continue
+
+            template = context.render_context.template
+            if not hasattr(template, 'get_exception_info'):
+                continue
+
+            # Extract template info for this frame
+            if not (hasattr(node.token, 'position') and node.token.position):
+                template_info = _get_template_info_manual_fallback(
+                    template, node)
+            elif hasattr(node, 'origin') and node.origin:
+                # Use node's origin (inheritance scenario)
+                node_origin_name = (node.origin.name
+                                    if hasattr(node.origin, 'name')
+                                    else str(node.origin))
+                template_info = {
+                    'name': os.path.basename(node_origin_name),
+                    'origin': node_origin_name
+                }
+                template_info.update(_get_line_info_from_node_origin(node))
+            else:
+                # Use Django's debugging
+                debug_info = template.get_exception_info(
+                    Exception("Template debugging probe"), node.token)
+                template_info = {
+                    'name': template.name or 'unknown',
+                    'origin': (template.origin.name if template.origin
+                               else 'unknown')
+                }
+
+                if debug_info.get('line', 0) > 0:
+                    template_info['line_number'] = debug_info['line']
+                if debug_info.get('during', '').strip():
+                    template_info['line_content'] = (
+                        debug_info['during'].strip())
+
+            # Add to chain if we have valid info and haven't seen this
+            # template+line combo
+            if template_info:
+                template_key = (template_info['origin'],
+                                template_info.get('line_number', 0))
+                if template_key not in seen_templates:
+                    seen_templates.add(template_key)
+                    template_chain.append(template_info)
+
+        return list(reversed(template_chain)) if template_chain else None
+
+    def _add_query_info(query, query_type, subqueries=None):
+        """Helper to add query info with template debugging."""
+        sql = _serialize_caught_sql(query)
+        if not sql:
+            return
+
+        query_info = {
+            'query': query,
+            'result_type': 'query',
+            'sql': sql,
+            'subqueries': subqueries or [],
+            'traceback': traceback.format_stack(),
+            'type': query_type,
+        }
+
+        # Add template debugging information if available
+        template_chain = _get_template_info_for_query(None)
+        if template_chain:
+            query_info['template_info'] = template_chain
+
+        executed_queries.append(query_info)
+
+    def _call_original_execute_sql(compiler_class, _self, *args, **kwargs):
+        """Helper to call original execute_sql method, handling library
+        conflicts."""
+        execute_sql_method = getattr(compiler_class, 'execute_sql')
+
+        if hasattr(execute_sql_method, 'call_original'):
+            return execute_sql_method.call_original(_self, *args, **kwargs)
+        else:
+            # Fallback for libraries like cachalot that also patch execute_sql
+            method = execute_sql_method
+            while hasattr(method, '__wrapped__'):
+                method = method.__wrapped__
+            return method(_self, *args, **kwargs)
+
     # Track Query objects any time a compiler is executing SQL.
     @spy_agency.spy_for(SQLCompiler.execute_sql,
                         owner=SQLCompiler)
@@ -194,27 +389,17 @@ def catch_queries(
             query_type = ExecutedQueryType.SELECT
 
         query = _self.query
-        sql = _serialize_caught_sql(query)
+        subqueries: List[ExecutedSubQueryInfo] = []
 
-        if sql:
-            subqueries: List[ExecutedSubQueryInfo] = []
+        if _check_subqueries:
+            _scan_subqueries(node=query,
+                             result=subqueries,
+                             queries_to_qs=queries_to_qs,
+                             _check_subqueries=_check_subqueries)
 
-            if _check_subqueries:
-                _scan_subqueries(node=query,
-                                 result=subqueries,
-                                 queries_to_qs=queries_to_qs,
-                                 _check_subqueries=_check_subqueries)
-
-            executed_queries.append({
-                'query': query,
-                'result_type': 'query',
-                'sql': sql,
-                'subqueries': subqueries,
-                'traceback': traceback.format_stack(),
-                'type': query_type,
-            })
-
-        return SQLCompiler.execute_sql.call_original(_self, *args, **kwargs)
+        _add_query_info(query, query_type, subqueries)
+        return _call_original_execute_sql(
+            SQLCompiler, _self, *args, **kwargs)
 
     @spy_agency.spy_for(SQLInsertCompiler.execute_sql,
                         owner=SQLInsertCompiler)
@@ -223,21 +408,9 @@ def catch_queries(
         *args,
         **kwargs,
     ) -> Any:
-        query = _self.query
-        sql = _serialize_caught_sql(query)
-
-        if sql:
-            executed_queries.append({
-                'query': query,
-                'result_type': 'query',
-                'sql': sql,
-                'subqueries': [],
-                'traceback': traceback.format_stack(),
-                'type': ExecutedQueryType.INSERT,
-            })
-
-        return SQLInsertCompiler.execute_sql.call_original(_self, *args,
-                                                           **kwargs)
+        _add_query_info(_self.query, ExecutedQueryType.INSERT)
+        return _call_original_execute_sql(
+            SQLInsertCompiler, _self, *args, **kwargs)
 
     # Build and track Q() objects any time they're added to a Query.
     @spy_agency.spy_for(SQLQuery.add_q, owner=SQLQuery)
@@ -269,6 +442,9 @@ def catch_queries(
             pass
 
         return result
+
+    # Template debugging now uses Django's stack inspection approach
+    # No spies needed - we inspect the call stack during query execution
 
     # Listen for any deletions and record their primary keys before they're
     # unset.

--- a/django_assert_queries/query_comparator.py
+++ b/django_assert_queries/query_comparator.py
@@ -637,6 +637,7 @@ def _check_queries(
                 'query_sql': cast(Optional[List[str]],
                                   executed_query_info.get('sql')),
                 'subqueries': subqueries_compare_ctx,
+                'template_info': executed_query_info.get('template_info'),
                 'traceback': cast(Optional[List[str]],
                                   executed_query_info.get('traceback')),
             })

--- a/django_assert_queries/query_comparator.py
+++ b/django_assert_queries/query_comparator.py
@@ -30,7 +30,6 @@ from typing_extensions import Literal, NotRequired, TypeAlias, TypedDict
 from django_assert_queries.query_catcher import catch_queries
 
 if TYPE_CHECKING:
-    from django.db.models import Model
     from django.db.models.expressions import BaseExpression
 
     from django_assert_queries.query_catcher import (CatchQueriesContext,
@@ -734,7 +733,9 @@ def _check_query(
         executed_query (django.db.models.sql.query.Query):
             The executed query to compare.
 
-        executed_query_info (django_assert_queries.query_catcher.ExecutedQueryInfo):
+        executed_query_info (
+            django_assert_queries.query_catcher.ExecutedQueryInfo
+        ):
             Information on the executed query to use for comparison.
 
         expected_query_info (dict):

--- a/django_assert_queries/testing.py
+++ b/django_assert_queries/testing.py
@@ -156,6 +156,7 @@ def assert_queries(
                     note = mismatch_info['note']
                     traceback = mismatch_info.get('traceback')
                     query_sql = mismatch_info.get('query_sql') or []
+                    template_info = mismatch_info.get('template_info')
 
                     if note:
                         title = f'{indent}Query {i + 1} ({note}):'
@@ -191,6 +192,79 @@ def assert_queries(
                             ''.join(traceback[-traceback_size:])
                         error_lines.append(
                             f'{indent}Trace: {traceback_str}')
+
+                    if template_info:
+                        # template_info is now a list of templates in the
+                        # inheritance chain
+                        if isinstance(template_info, list):
+                            error_lines.append(
+                                f'{indent}  Template inheritance chain:')
+                            for i, template_data in enumerate(template_info):
+                                template_name = template_data.get(
+                                    "name", "unknown")
+                                template_origin = template_data.get(
+                                    "origin", "unknown")
+                                line_number = template_data.get("line_number")
+                                line_content = template_data.get(
+                                    "line_content")
+
+                                # Choose template identifier: prefer full path
+                                # for files, name for strings
+                                if template_origin and template_origin not in (
+                                        "unknown", "<unknown source>"):
+                                    template_identifier = template_origin
+                                elif (template_name and
+                                      template_name != "unknown"):
+                                    template_identifier = template_name
+                                else:
+                                    template_identifier = template_origin
+
+                                if line_number:
+                                    error_lines.append(
+                                        f'{indent}    [{i + 1}] In template '
+                                        f'{template_identifier}, error at '
+                                        f'line {line_number}')
+                                    if line_content:
+                                        error_lines.append(
+                                            f'{indent}        {line_number}  '
+                                            f'{line_content}')
+                                else:
+                                    error_lines.append(
+                                        f'{indent}    [{i + 1}] Template: '
+                                        f'{template_name} ({template_origin})')
+                        else:
+                            # Backward compatibility: single template info
+                            # (shouldn't happen with new code)
+                            template_name = template_info.get(
+                                "name", "unknown")
+                            template_origin = template_info.get(
+                                "origin", "unknown")
+                            line_number = template_info.get("line_number")
+                            line_content = template_info.get("line_content")
+
+                            # Choose template identifier: prefer full path
+                            # for files, name for strings
+                            if template_origin and template_origin not in (
+                                    "unknown", "<unknown source>"):
+                                template_identifier = template_origin
+                            elif template_name and template_name != "unknown":
+                                template_identifier = template_name
+                            else:
+                                template_identifier = template_origin
+
+                            if line_number:
+                                error_lines.append(
+                                    f'{indent}  In template '
+                                    f'{template_identifier}, error at line '
+                                    f'{line_number}')
+                                if line_content:
+                                    error_lines.append(
+                                        f'{indent}    {line_number}    '
+                                        f'{line_content}')
+                            else:
+                                error_lines.append(
+                                    f'{indent}  Template: {template_name} '
+                                    f'({template_origin})')
 
         return error_lines
 

--- a/django_assert_queries/tests/test_query_catcher.py
+++ b/django_assert_queries/tests/test_query_catcher.py
@@ -909,3 +909,40 @@ class CaptureQueriesTests(TestCase):
                 extra_ws_re.sub(' ', _line)
                 for _line in sql2
             ))
+
+    def test_with_template_rendering(self) -> None:
+        """Testing capture_queries with template rendering"""
+        from django.template import Context, Template
+
+        TestModel.objects.bulk_create([
+            TestModel(name='test1'),
+            TestModel(name='test2'),
+        ])
+
+        template_content = """
+        {% for obj in objects %}
+            {{ obj.name }}
+        {% endfor %}
+        """
+
+        template = Template(template_content)
+        context = Context({'objects': TestModel.objects.all()})
+
+        with catch_queries() as ctx:
+            template.render(context)
+
+        self.assertEqual(len(ctx.executed_queries), 1)
+        query_info = ctx.executed_queries[0]
+
+        # Check that template_info is captured
+        self.assertIn('template_info', query_info)
+        template_info = query_info['template_info']
+
+        # template_info is now a list of templates in the inheritance chain
+        self.assertIsInstance(template_info, list)
+        self.assertTrue(len(template_info) > 0)
+
+        # Check the first template in the chain
+        first_template = template_info[0]
+        self.assertEqual(first_template['name'], 'unknown')
+        self.assertIn('unknown', first_template['origin'])

--- a/django_assert_queries/tests/test_query_catcher.py
+++ b/django_assert_queries/tests/test_query_catcher.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 import re
 from typing import Any, List, Optional, TYPE_CHECKING, Type
 
+import django
 from django.db.models import Exists, OuterRef, Q, QuerySet, Subquery, Sum
 from django.db.models.sql.subqueries import AggregateQuery
 from django.test.testcases import TestCase
@@ -28,6 +29,16 @@ class CaptureQueriesTests(TestCase):
     """Unit tests for djblets.db.query_catcher.catch_queries."""
 
     tests_app = 'djblets.db.tests'
+
+    def _get_subquery_pk_sql(self, alias: str) -> str:
+        """Get the correct subquery PK SQL based on Django version.
+
+        Django 5.2+ adds 'AS "pk"' to subqueries, while earlier versions don't.
+        """
+        if django.VERSION >= (5, 2):
+            return f'{alias}."id" AS "pk"'
+        else:
+            return f'{alias}."id"'
 
     maxDiff = None
 
@@ -275,7 +286,7 @@ class CaptureQueriesTests(TestCase):
                 ' "tests_testmodel"."name",'
                 ' "tests_testmodel"."flag", '
                 ' "tests_testmodel"."user_id", '
-                ' (SELECT U0."id"'
+                f' (SELECT {self._get_subquery_pk_sql("U0")}'
                 '   FROM "tests_reltestmodel" U0'
                 '   WHERE'
                 '    U0."test_id" ='
@@ -543,7 +554,7 @@ class CaptureQueriesTests(TestCase):
                 '  ("tests_testmodel"."name"'
                 '    LIKE test% ESCAPE \'\\\' AND'
                 '   "tests_testmodel"."id" IN'
-                '    (SELECT U0."id" FROM'
+                f'    (SELECT {self._get_subquery_pk_sql("U0")} FROM'
                 '      "tests_reltestmodel" U0))',
             ],
 
@@ -679,7 +690,7 @@ class CaptureQueriesTests(TestCase):
                 '  "tests_testmodel"."name" AS "col2",'
                 '  "tests_testmodel"."flag" AS "col3",'
                 '  "tests_testmodel"."user_id" AS "col4",'
-                '  (SELECT V0."id"'
+                f'  (SELECT {self._get_subquery_pk_sql("V0")}'
                 '    FROM "tests_reltestmodel" V0'
                 '    WHERE (V0."test_id" ='
                 '     ("tests_testmodel"."id") AND'

--- a/django_assert_queries/tests/test_template_debugging.py
+++ b/django_assert_queries/tests/test_template_debugging.py
@@ -1,0 +1,719 @@
+"""Unit tests for template debugging functionality.
+
+Version Added:
+    2.1
+"""
+
+from __future__ import annotations
+
+import os
+import tempfile
+
+from django.template import Context, Template, engines
+from django.template.loader import get_template
+from django.test.testcases import TestCase
+
+from django_assert_queries.testing import assert_queries
+from django_assert_queries.query_catcher import catch_queries
+from django_assert_queries.tests.models import TestModel
+
+
+class TemplateDebuggingTests(TestCase):
+    """Unit tests for template debugging functionality."""
+
+    def setUp(self) -> None:
+        """Set up test data."""
+        TestModel.objects.all().delete()
+        TestModel.objects.bulk_create(
+            [
+                TestModel(name="test1"),
+                TestModel(name="test2"),
+            ]
+        )
+
+    def _extract_template_chain(self, error_message: str) -> list[str]:
+        """Extract the template inheritance chain block from error message."""
+        lines = error_message.split("\n")
+        chain_lines = []
+        in_template_section = False
+
+        for line in lines:
+            if "Template inheritance chain:" in line:
+                in_template_section = True
+                chain_lines.append(line.strip())
+            elif in_template_section:
+                if line.strip() and not line.startswith("  "):
+                    # End of template section
+                    break
+                if line.strip():  # Skip empty lines
+                    chain_lines.append(line.strip())
+
+        return chain_lines
+
+    def test_template_info_missing_when_no_template_context(self) -> None:
+        """Testing that template_info is missing when no template context
+        available."""
+        # Execute query outside of template context
+        with catch_queries() as ctx:
+            list(TestModel.objects.all())
+
+        self.assertEqual(len(ctx.executed_queries), 1)
+        query_info = ctx.executed_queries[0]
+
+        # Should not have template_info when not in template context
+        self.assertNotIn("template_info", query_info)
+
+    def test_template_info_capture_basic_functionality(self) -> None:
+        """Testing basic template info capture functionality."""
+        template_content = "{% for obj in objects %}{{ obj.name }}{% endfor %}"
+
+        # Test with assert_queries to get the complete template chain
+        # validation
+        expected_queries = [
+            {
+                "model": TestModel,
+                # Force mismatch to see template info
+                "tables": {"wrong_table_name"},
+            }
+        ]
+
+        with self.assertRaises(AssertionError) as cm:
+            with assert_queries(expected_queries, with_tracebacks=True):
+                template = Template(template_content)
+                context = Context({"objects": TestModel.objects.all()})
+                template.render(context)
+
+        error_message = str(cm.exception)
+
+        # Extract and validate template chain
+        template_chain = self._extract_template_chain(error_message)
+
+        # Expected template chain for basic functionality test
+        expected_chain = [
+            "Template inheritance chain:",
+            "[1] In template <unknown source>, error at line 1",
+            "1  {% for obj in objects %}{{ obj.name }}{% endfor %}",
+        ]
+
+        self.assertEqual(template_chain, expected_chain)
+
+    def test_django_style_output_format(self) -> None:
+        """Testing Django-style template error output format when available."""
+        template_content = "{% for obj in objects %}{{ obj.name }}{% endfor %}"
+
+        expected_queries = [
+            {
+                "model": TestModel,
+                # Force mismatch to see template info
+                "tables": {"wrong_table_name"},
+            }
+        ]
+
+        with self.assertRaises(AssertionError) as cm:
+            with assert_queries(expected_queries, with_tracebacks=True):
+                template = Template(template_content)
+                context = Context({"objects": TestModel.objects.all()})
+                template.render(context)
+
+        error_message = str(cm.exception)
+
+        # The error should contain query mismatch information
+        self.assertIn("1 query failed to meet expectations", error_message)
+        self.assertIn("tables:", error_message)
+
+        # Extract and validate template chain
+        template_chain = self._extract_template_chain(error_message)
+
+        # Expected template chain for simple template
+        expected_chain = [
+            "Template inheritance chain:",
+            "[1] In template <unknown source>, error at line 1",
+            "1  {% for obj in objects %}{{ obj.name }}{% endfor %}",
+        ]
+
+        self.assertEqual(template_chain, expected_chain)
+
+    def test_fail_fast_behavior_with_template_debugging(self) -> None:
+        """Testing that template debugging follows fail-fast principle."""
+        template_content = "{% for obj in objects %}{{ obj.name }}{% endfor %}"
+
+        # Test with assert_queries to validate complete template chain and
+        # fail-fast behavior
+        expected_queries = [
+            {
+                "model": TestModel,
+                # Force mismatch to test fail-fast
+                "tables": {"wrong_table_name"},
+            }
+        ]
+
+        with self.assertRaises(AssertionError) as cm:
+            with assert_queries(expected_queries, with_tracebacks=True):
+                template = Template(template_content)
+                context = Context({"objects": TestModel.objects.all()})
+                template.render(context)
+
+        error_message = str(cm.exception)
+
+        # Extract and validate template chain - should fail fast with clear
+        # template info
+        template_chain = self._extract_template_chain(error_message)
+
+        # Expected template chain for fail-fast test
+        expected_chain = [
+            "Template inheritance chain:",
+            "[1] In template <unknown source>, error at line 1",
+            "1  {% for obj in objects %}{{ obj.name }}{% endfor %}",
+        ]
+
+        self.assertEqual(template_chain, expected_chain)
+
+    def test_delayed_query_execution_issue(self) -> None:
+        """Testing that template debugging now works correctly.
+
+        This test verifies that the QuerySet tracking approach successfully
+        captures template information for queries executed during template
+        rendering.
+        """
+        # Simple template to test template debugging
+        template_content = """<div>Some content before</div>
+            <p>Some text</p>
+            {% for obj in objects %}
+                <p>{{ obj.name }}</p>
+            {% endfor %}
+            <div id="dpi" style="height: 1in; width: 1in;">
+                DPI measurement div
+            </div>
+            """
+
+        # First test with catch_queries to see if template_info is captured
+        with catch_queries() as ctx:
+            template = Template(template_content)
+            context = Context({"objects": TestModel.objects.all()})
+            template.render(context)
+
+        self.assertEqual(len(ctx.executed_queries), 1)
+        query_info = ctx.executed_queries[0]
+
+        # Check if template_info is present
+        self.assertIn(
+            "template_info",
+            query_info,
+            "Template debugging should capture template_info",
+        )
+
+        template_info = query_info["template_info"]
+        # template_info is now a list of templates in the inheritance chain
+        self.assertIsInstance(template_info, list)
+        self.assertTrue(len(template_info) > 0)
+
+        # Check the first template in the chain (where the query actually
+        # executes)
+        first_template = template_info[0]
+        self.assertIn("name", first_template)
+        self.assertIn("origin", first_template)
+
+        # In test environments, we might not get precise line numbers
+        # but we should at least get basic template information
+        if (
+            "line_number" in first_template and
+            first_template["line_number"] > 0
+        ):
+            # We have precise line information
+            # {% for %} is on line 3
+            self.assertEqual(first_template["line_number"], 3)
+            if "line_content" in first_template:
+                self.assertIn(
+                    "{% for obj in objects %}", first_template["line_content"]
+                )
+        else:
+            # Basic template info without precise line numbers
+            # (test environment)
+            # Template name should be captured
+            self.assertIn("unknown", first_template["name"])
+
+        # Now test with assert_queries to see if it formats correctly
+        expected_queries = [
+            {
+                "model": TestModel,
+                "tables": {"wrong_table_name"},  # Force mismatch
+            }
+        ]
+
+        with self.assertRaises(AssertionError) as cm:
+            with assert_queries(expected_queries, with_tracebacks=True):
+                template2 = Template(template_content)
+                context2 = Context({"objects": TestModel.objects.all()})
+                template2.render(context2)
+
+        error_message = str(cm.exception)
+
+        # Extract and validate template chain
+        template_chain = self._extract_template_chain(error_message)
+
+        # Expected template chain for multi-line template
+        expected_chain = [
+            "Template inheritance chain:",
+            "[1] In template <unknown source>, error at line 3",
+            "3  {% for obj in objects %}",
+        ]
+
+        self.assertEqual(template_chain, expected_chain)
+
+    def test_nested_template_rendering_issue(self) -> None:
+        """Testing template debugging with nested rendering contexts.
+
+        This test currently passes because we're using simple templates.
+        In real-world scenarios with template inheritance, the issue is that
+        queries from child templates might be attributed to parent templates.
+
+        This test serves as a placeholder for future template inheritance
+        testing.
+        """
+        # Simple template that should work correctly
+        template_content = """<html>
+            <head><title>Base</title></head>
+            <body>
+                {% for obj in objects %}
+                    {{ obj.name }}
+                {% endfor %}
+            </body>
+            </html>"""
+
+        expected_queries = [
+            {
+                "model": TestModel,
+                "tables": {"wrong_table_name"},  # Force mismatch
+            }
+        ]
+
+        with self.assertRaises(AssertionError) as cm:
+            with assert_queries(expected_queries, with_tracebacks=True):
+                template = Template(template_content)
+                context = Context({"objects": TestModel.objects.all()})
+                template.render(context)
+
+        error_message = str(cm.exception)
+
+        # Extract and validate template chain
+        template_chain = self._extract_template_chain(error_message)
+
+        # Expected template chain for nested HTML template
+        expected_chain = [
+            "Template inheritance chain:",
+            "[1] In template <unknown source>, error at line 4",
+            "4  {% for obj in objects %}",
+        ]
+
+        self.assertEqual(template_chain, expected_chain)
+
+    def test_sitetree_missing_line_number_issue(self) -> None:
+        """Testing the sitetree issue where queries show template name but no
+        line number.
+
+        Real-world example from Query 12:
+        - Expected: "In template base.html, error at line X" with specific
+          line
+        - Actual: "Template: base.html (/path/to/base.html)"
+                  with no line number
+        """
+        # Simulate a sitetree-like scenario with complex template
+        template_content = """<html>
+            <head><title>Test</title></head>
+            <body>
+                <nav>
+                    {% comment %}
+                    This simulates sitetree_menu location
+                    {% endcomment %}
+                    {% for obj in menu_objects %}
+                        <a href="#">{{ obj.name }}</a>
+                    {% endfor %}
+                </nav>
+            </body>
+            </html>"""
+
+        expected_queries = [
+            {
+                "model": TestModel,
+                "tables": {"wrong_table_name"},  # Force mismatch
+            }
+        ]
+
+        with self.assertRaises(AssertionError) as cm:
+            with assert_queries(expected_queries, with_tracebacks=True):
+                template = Template(template_content)
+                context = Context({"menu_objects": TestModel.objects.all()})
+                template.render(context)
+
+        error_message = str(cm.exception)
+
+        # Extract and validate template chain
+        template_chain = self._extract_template_chain(error_message)
+
+        # Expected template chain for sitetree-like template
+        expected_chain = [
+            "Template inheritance chain:",
+            "[1] In template <unknown source>, error at line 8",
+            "8  {% for obj in menu_objects %}",
+        ]
+
+        self.assertEqual(template_chain, expected_chain)
+
+    def test_queryset_lazy_evaluation_timing_issue(self) -> None:
+        """Testing the core issue: QuerySet creation vs execution timing.
+
+        This test demonstrates how Django's lazy QuerySet evaluation can cause
+        template debugging to point to the wrong location.
+
+        The issue:
+        1. Template tag creates QuerySet (no query executed yet)
+        2. QuerySet gets passed around in template context
+        3. Query finally executes when a different template node evaluates it
+        4. Template debugging captures the wrong node's context
+        """
+        # Template that creates a QuerySet but doesn't immediately evaluate
+        # it
+        template_content = """
+            <h1>Header</h1>
+            {% with queryset=objects %}
+                <p>Queryset created but not evaluated yet</p>
+                {% comment %}
+                Query will execute on next line when len() is called
+                {% endcomment %}
+                <p>Count: {{ queryset|length }}</p>
+            {% endwith %}
+            <p>Footer</p>
+            """
+
+        expected_queries = [
+            {
+                "model": TestModel,
+                "tables": {"wrong_table_name"},  # Force mismatch
+            }
+        ]
+
+        with self.assertRaises(AssertionError) as cm:
+            with assert_queries(expected_queries, with_tracebacks=True):
+                template = Template(template_content)
+                context = Context({"objects": TestModel.objects.all()})
+                template.render(context)
+
+        error_message = str(cm.exception)
+
+        # Extract and validate template chain
+        template_chain = self._extract_template_chain(error_message)
+
+        # Expected template chain for lazy evaluation template
+        # Shows both the {% with %} context and the actual query execution
+        expected_chain = [
+            "Template inheritance chain:",
+            "[1] In template <unknown source>, error at line 3",
+            "3  {% with queryset=objects %}",
+            "[2] In template <unknown source>, error at line 8",
+            "8  <p>Count: {{ queryset|length }}</p>",
+        ]
+
+        self.assertEqual(template_chain, expected_chain)
+
+    def test_wrong_line_attribution_issue(self) -> None:
+        """Testing wrong line attribution like Query 13.
+
+        Real-world example from Query 13:
+        - Query comes from sitetree breadcrumbs (line with sitetree tag)
+        - But template debugging points to line 41 (meta description tag)
+        - Expected: Should point to the line
+                    with the actual sitetree template tag
+        """
+        # Recreate scenario similar to Query 13
+        template_content = """<!DOCTYPE html>
+            <html>
+            <head>
+                <meta name="description" content="Download free 3D models">
+                <title>Test Page</title>
+            </head>
+            <body>
+                <nav>
+                    {% comment %}
+                    This simulates sitetree_breadcrumbs location
+                    {% endcomment %}
+                    {% for obj in breadcrumb_objects %}
+                        <span>{{ obj.name }}</span>
+                    {% endfor %}
+                </nav>
+                <main>
+                    <h1>Main Content</h1>
+                </main>
+            </body>
+            </html>"""
+
+        expected_queries = [
+            {
+                "model": TestModel,
+                "tables": {"wrong_table_name"},  # Force mismatch
+            }
+        ]
+
+        with self.assertRaises(AssertionError) as cm:
+            with assert_queries(expected_queries, with_tracebacks=True):
+                template = Template(template_content)
+                context = Context(
+                    {"breadcrumb_objects": TestModel.objects.all()}
+                )
+                template.render(context)
+
+        error_message = str(cm.exception)
+
+        # Extract and validate template chain
+        template_chain = self._extract_template_chain(error_message)
+
+        # Expected template chain for breadcrumb template
+        expected_chain = [
+            "Template inheritance chain:",
+            "[1] In template <unknown source>, error at line 12",
+            "12  {% for obj in breadcrumb_objects %}",
+        ]
+
+        self.assertEqual(template_chain, expected_chain)
+
+    def test_template_inheritance_issue(self):
+        """
+        CRITICAL TEST: Template inheritance detection issue.
+
+        This test verifies that template debugging correctly identifies
+        templates in inheritance scenarios and shows the complete
+        template chain.
+        """
+        # Simple template - this should work fine
+        template_content = """<div>Test template</div>
+        {% for obj in objects %}{{ obj.name }}{% endfor %}
+        <div>End</div>"""
+
+        expected_queries = [
+            {
+                "model": TestModel,
+                # Force mismatch to see template info
+                "tables": {"wrong_table"},
+            }
+        ]
+
+        with self.assertRaises(AssertionError) as cm:
+            with assert_queries(expected_queries, with_tracebacks=True):
+                template = Template(
+                    template_content, name="test_inheritance.html"
+                )
+                context = Context({"objects": TestModel.objects.all()})
+                template.render(context)
+
+        error_message = str(cm.exception)
+
+        # Extract and validate template chain
+        template_chain = self._extract_template_chain(error_message)
+
+        # Expected template chain for inheritance test
+        expected_chain = [
+            "Template inheritance chain:",
+            "[1] In template test_inheritance.html, error at line 2",
+            "2  {% for obj in objects %}{{ obj.name }}{% endfor %}",
+        ]
+
+        self.assertEqual(template_chain, expected_chain)
+
+    def test_block_super_attribution_issue(self) -> None:
+        """
+        TEST: Block.super attribution works correctly.
+
+        This test verifies that when {{ block.super }} is called in a
+        child template, queries that originate in the parent template
+        are correctly attributed to the parent template, not the
+        child template's {{ block.super }} call.
+
+        Real-world example from blenderhub_server:
+        - Child template: base_profile.html calls {{ block.super }}
+        - Parent template: base.html has {% for user in users %}
+        - Expected: Should show "base.html, line X: {% for user in users %}"
+        - Not: "base_profile.html, line 56: {{ block.super }}"
+        """
+        # Create a realistic block.super scenario with
+        # actual template inheritance
+        with tempfile.TemporaryDirectory() as temp_dir:
+            # Parent template with query-causing code
+            parent_template_content = """<!DOCTYPE html>
+                <html>
+                <head><title>Parent Template</title></head>
+                <body>
+                {% block content %}
+                        <h1>Parent Content</h1>
+                        {% comment %}
+                        This is where the actual query happens
+                        {% endcomment %}
+                    {% for obj in objects %}
+                            <p>Parent: {{ obj.name }}</p>
+                        {% endfor %}
+                    {% endblock %}
+                </body>
+                </html>"""
+
+            # Child template that calls block.super
+            child_template_content = """{% extends "parent.html" %}
+                {% block content %}
+                    <div>Child template content</div>
+                    {% comment %}
+                    This calls parent code -
+                    query should be attributed to parent
+                    {% endcomment %}
+                    {{ block.super }}
+                    <div>End of child content</div>
+                {% endblock %}"""
+
+            # Write templates to files
+            parent_path = os.path.join(temp_dir, "parent.html")
+            child_path = os.path.join(temp_dir, "child.html")
+
+            with open(parent_path, "w") as f:
+                f.write(parent_template_content)
+
+            with open(child_path, "w") as f:
+                f.write(child_template_content)
+
+            # Add temp directory to Django template dirs
+            engine = engines["django"]
+            engine.engine.dirs.append(temp_dir)
+
+            expected_queries = [
+                {
+                    "model": TestModel,
+                    # Force mismatch to see template info
+                    "tables": {"wrong_table_name"},
+                }
+            ]
+
+            with self.assertRaises(AssertionError) as cm:
+                with assert_queries(expected_queries, with_tracebacks=True):
+                    template = get_template("child.html")
+                    context = {"objects": TestModel.objects.all()}
+                    template.render(context)
+
+            error_message = str(cm.exception)
+
+            # Extract and validate template chain
+            template_chain = self._extract_template_chain(error_message)
+
+            # Expected template chain for block.super scenario
+            # This shows the complete inheritance chain with proper attribution
+            expected_chain = [
+                "Template inheritance chain:",
+                f"[1] In template {parent_path}, error at line 5",
+                "5  {% block content %}",
+                f"[2] Template: parent.html ({parent_path})",
+                f"[3] In template {parent_path}, error at line 10",
+                "10  {% for obj in objects %}",
+            ]
+
+            self.assertEqual(template_chain, expected_chain)
+
+    def test_basic_template_debugging_functionality(self) -> None:
+        """
+        TEST: Basic template debugging functionality works correctly.
+
+        This test verifies that the core template debugging features work:
+        1. Template name detection
+        2. Line number detection
+        3. Line content extraction
+        4. Django-style error format
+        """
+        # Simple template with clear line structure
+        template_content = """<h1>Header</h1>
+<p>Some content</p>
+{% for obj in objects %}
+    <span>{{ obj.name }}</span>
+{% endfor %}
+<p>Footer</p>"""
+
+        expected_queries = [
+            {
+                "model": TestModel,
+                "tables": {"wrong_table_name"},  # Force mismatch
+            }
+        ]
+
+        # Create a temporary template file
+        with tempfile.TemporaryDirectory() as temp_dir:
+            template_path = os.path.join(temp_dir, "test_basic_template.html")
+            with open(template_path, "w") as f:
+                f.write(template_content)
+
+            # Add temporary directory to Django template dirs
+            engine = engines["django"]
+            engine.engine.dirs.append(temp_dir)
+
+            with self.assertRaises(AssertionError) as cm:
+                with assert_queries(expected_queries, with_tracebacks=True):
+                    template = get_template("test_basic_template.html")
+                    context = {"objects": TestModel.objects.all()}
+                    template.render(context)
+
+        error_message = str(cm.exception)
+
+        # Extract and validate template chain
+        template_chain = self._extract_template_chain(error_message)
+
+        # Expected template chain for file-based template
+        # (should show full path)
+        expected_chain = [
+            "Template inheritance chain:",
+            f"[1] In template {template_path}, error at line 3",
+            "3  {% for obj in objects %}",
+        ]
+
+        self.assertEqual(template_chain, expected_chain)
+
+    def test_real_file_path_detection(self) -> None:
+        """
+        TEST: Real file paths are detected correctly.
+
+        This test verifies that when templates are loaded from actual files
+        (not string content), the full file paths are captured correctly.
+        """
+        with tempfile.TemporaryDirectory() as temp_dir:
+            # Create a real template file
+            template_path = os.path.join(temp_dir, "real_file_template.html")
+            template_content = """<h1>Real File Template</h1>
+                <div>Content</div>
+                {% for obj in objects %}
+                    <p>{{ obj.name }}</p>
+                {% endfor %}
+                <footer>End</footer>"""
+
+            with open(template_path, "w") as f:
+                f.write(template_content)
+
+            # Add temp directory to template dirs
+            engine = engines["django"]
+            engine.engine.dirs.insert(0, temp_dir)
+
+            expected_queries = [
+                {
+                    "model": TestModel,
+                    "tables": {"wrong_table_name"},  # Force mismatch
+                }
+            ]
+
+            with self.assertRaises(AssertionError) as cm:
+                with assert_queries(expected_queries, with_tracebacks=True):
+                    template = get_template("real_file_template.html")
+                    context = {"objects": TestModel.objects.all()}
+                    template.render(context)
+
+            error_message = str(cm.exception)
+
+            # Extract and validate template chain
+            template_chain = self._extract_template_chain(error_message)
+
+            # Expected template chain for real file template
+            expected_chain = [
+                "Template inheritance chain:",
+                f"[1] In template {template_path}, error at line 3",
+                "3  {% for obj in objects %}",
+            ]
+
+            self.assertEqual(template_chain, expected_chain)

--- a/tests/settings.py
+++ b/tests/settings.py
@@ -18,5 +18,32 @@ INSTALLED_APPS = [
     'django.contrib.sessions',
     'django.contrib.sites',
     'django.contrib.staticfiles',
+    'django.contrib.messages',
     'django_assert_queries.tests',
+]
+
+TEMPLATES = [
+    {
+        'BACKEND': 'django.template.backends.django.DjangoTemplates',
+        'DIRS': [],
+        'APP_DIRS': True,
+        'OPTIONS': {
+            'context_processors': [
+                'django.template.context_processors.debug',
+                'django.template.context_processors.request',
+                'django.contrib.auth.context_processors.auth',
+                'django.contrib.messages.context_processors.messages',
+            ],
+        },
+    },
+]
+
+MIDDLEWARE = [
+    'django.middleware.security.SecurityMiddleware',
+    'django.contrib.sessions.middleware.SessionMiddleware',
+    'django.middleware.common.CommonMiddleware',
+    'django.middleware.csrf.CsrfViewMiddleware',
+    'django.contrib.auth.middleware.AuthenticationMiddleware',
+    'django.contrib.messages.middleware.MessageMiddleware',
+    'django.middleware.clickjacking.XFrameOptionsMiddleware',
 ]

--- a/tox.ini
+++ b/tox.ini
@@ -2,6 +2,7 @@
 envlist =
 	py{38,39,310,311,312}-django4_2,
 	py{310,311,312}-django5_1,
+	py{310,311,312}-django5_2,
 
 skipsdist = True
 
@@ -13,6 +14,7 @@ deps =
 	-r dev-requirements.txt
 	django4_2: Django~=4.2.16
 	django5_1: Django~=5.1.1
+	django5_2: Django~=5.2.0
 
 passenv = *
 setenv =


### PR DESCRIPTION
When using `with_tracebacks=True`, output also templates, line numbers and lines when the query comes from a template.

This PR contains commits from #3, which is meant to be pulled first. When it is pulled, I can rebase this to run the tests.

Example output:
```
                                                                                                                                                                                                                                                                                              
  Template inheritance chain:                                                                                                                                                                                                                                                                 
    [1] In template apps/plans_overrides/templates/plans/pricing.html, error at line 1                                                                                                                                
        1  {% extends "base.html" %}                                                                                                                                                                                                                                                          
    [2] In template templates/base.html, error at line 191                                                                                                                                                            
        191  {% block content_container %}                                                                                                                                                                                                                                                    
    [3] In templatetemplates/base.html, error at line 194                                                                                                                                                            
        194  {% block overridatble_content %}                                                                                                                                                                                                                                                 
    [4] In template templates/base.html, error at line 125                                                                                                                                                            
        125  <body class="{% if request.resolver_match %}{{ request.resolver_match.url_name }}{% endif %} {% if user.is_authenticated %}logged-in{% endif %} {% block body_extra_class %}{% endblock body_extra_class %}">                                                                    
    [5] In template apps/plans_overrides/templates/plans/pricing.html, error at line 48                                                                                                                               
        48  {% get_discount_message as pricing_message %}  
```